### PR TITLE
Fixed HTML highlight problem

### DIFF
--- a/script/render.mjs
+++ b/script/render.mjs
@@ -59,7 +59,7 @@ export function insertLinkToHome(document) {
 
 export function highlightCodes($) {
   $(
-    `pre code[class="language-haskell"], pre code[class="language-purescript"], pre code[class="language-javascript"]`
+    `pre code[class="language-haskell"], pre code[class="language-purescript"], pre code[class="language-javascript"], pre code[class="language-html"]`
   ).map((i, node) => {
     const result = highlightjs.highlightAuto($(node).text(), [
       "haskell",


### PR DESCRIPTION
This solves the problem that HTML highlights are not displayed.
For example, the problem is caused by the following part.

http://aratama.github.io/purescript/chapter08.html
次の行を除いて、HTMLファイルは基本的に空です。